### PR TITLE
Revert ""Gryffindor", not "Gryffendor""

### DIFF
--- a/consts.py
+++ b/consts.py
@@ -1,4 +1,4 @@
-HOUSES = ["Ravenclaw", "Hufflepuff", "Gryffindor", "Slytherin"]
+HOUSES = ["Ravenclaw", "Hufflepuff", "Gryffendor", "Slytherin"]
 SLACK_TOKEN = 'your_token_here'
 # only prefects can add and remove multiple points
 PREFECTS = ["your_slack_id_here", "someone_elses_here"]


### PR DESCRIPTION
Reverts eliawry/hogwarts#1
I need to fix all the spelling at once and make sure it will still work with the save files of running instances - I'll do this today, though. Thanks!
